### PR TITLE
Fix squeeze bug

### DIFF
--- a/wired_table_rec/utils_table_recover.py
+++ b/wired_table_rec/utils_table_recover.py
@@ -85,7 +85,7 @@ def merge_adjacent_polys(polygons: np.ndarray) -> np.ndarray:
 
 def combine_two_poly(polygons: np.ndarray, idxs: np.ndarray) -> np.ndarray:
     del_idxs, insert_boxes = [], []
-    idxs = idxs.squeeze(0)
+    idxs = idxs.squeeze(-1)
     for idx in idxs:
         # idx 和 idx + 1 是重合度过高的
         # 合并，取两者各个点的最大值


### PR DESCRIPTION
Hello，我在使用时发现`wired_table_rec/utils_table_recover.py`似乎有点小问题。

```python
def merge_adjacent_polys(polygons: np.ndarray) -> np.ndarray:
    """合并相邻iou大于阈值的框"""
    combine_iou_thresh = 0.1
    pair_polygons = list(zip(polygons, polygons[1:, ...]))
    pair_ious = np.array([compute_poly_iou(p1, p2) for p1, p2 in pair_polygons])
    idxs = np.argwhere(pair_ious >= combine_iou_thresh)    # shape: (n, 1)

    if idxs.size <= 0:
        return polygons

    polygons = combine_two_poly(polygons, idxs)
    ...

def combine_two_poly(polygons: np.ndarray, idxs: np.ndarray) -> np.ndarray:
    del_idxs, insert_boxes = [], []
    idxs = idxs.squeeze(0)   # -> idxs = idxs.squeeze(-1)
    for idx in idxs:
        ...
```
`idxs`的第一维不总是1，要压缩的大概是第二维。用这张图片可以复现问题，原代码报错`ValueError: cannot select an axis to squeeze out which has size not equal to one`
![bug](https://github.com/RapidAI/TableStructureRec/assets/79563000/23ff889e-8bd5-42f8-a013-c640cf47acd7)
