### PR TITLE
feature: optimize lineless table rec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,4 @@ long1.jpg
 
 .DS_Store
 *.npy
+/lineless_table_rec/output/

--- a/lineless_table_rec/utils_table_recover.py
+++ b/lineless_table_rec/utils_table_recover.py
@@ -1,12 +1,14 @@
 # -*- encoding: utf-8 -*-
 # @Author: SWHL
 # @Contact: liekkaskono@163.com
+import os
 import random
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Iterable, Union, Any
 
 import cv2
 import numpy as np
 import shapely
+from numpy import ndarray
 from shapely.geometry import MultiPoint, Polygon
 
 
@@ -26,8 +28,8 @@ def sorted_boxes(dt_boxes: np.ndarray) -> np.ndarray:
     for i in range(num_boxes - 1):
         for j in range(i, -1, -1):
             if (
-                abs(_boxes[j + 1][0][1] - _boxes[j][0][1]) < 10
-                and _boxes[j + 1][0][0] < _boxes[j][0][0]
+                    abs(_boxes[j + 1][0][1] - _boxes[j][0][1]) < 10
+                    and _boxes[j + 1][0][0] < _boxes[j][0][0]
             ):
                 _boxes[j], _boxes[j + 1] = _boxes[j + 1], _boxes[j]
             else:
@@ -64,6 +66,227 @@ def compute_poly_iou(a: np.ndarray, b: np.ndarray) -> float:
         return 0.0
 
     return float(inter_area) / union_area
+
+
+def filter_duplicated_box(table_boxes: list[list[float]]) -> set[int]:
+    """
+    :param table_boxes: [[xmin,ymin,xmax,ymax]]
+    :return:
+    """
+    delete_idx = set()
+    for i in range(len(table_boxes)):
+        polygons_i = table_boxes[i]
+        if i in delete_idx:
+            continue
+        for j in range(i + 1, len(table_boxes)):
+            if j in delete_idx:
+                continue
+            # 下一个box
+            polygons_j = table_boxes[j]
+            # 重叠关系先记录，后续删除掉
+            if calculate_iou(polygons_i, polygons_j) > 0.8:
+                delete_idx.add(j)
+                continue
+            # 是否存在包含关系
+            contained_idx = is_box_contained(polygons_i, polygons_j)
+            if contained_idx == 2:
+                delete_idx.add(j)
+            elif contained_idx == 1:
+                delete_idx.add(i)
+    return delete_idx
+
+
+def calculate_iou(box1: list | np.ndarray, box2: list | np.ndarray) -> float:
+    """
+    :param box1: Iterable [xmin,ymin,xmax,ymax]
+    :param box2: Iterable [xmin,ymin,xmax,ymax]
+    :return: iou: float 0-1
+    """
+    b1_x1, b1_y1, b1_x2, b1_y2 = box1[0], box1[1], box1[2], box1[3]
+    b2_x1, b2_y1, b2_x2, b2_y2 = box2[0], box2[1], box2[2], box2[3]
+    # 不相交直接退出检测
+    if b1_x2 < b2_x1 or b1_x1 > b2_x2 or b1_y2 < b2_y1 or b1_y1 > b2_y2:
+        return 0.0
+    # 计算交集
+    inter_x1 = max(b1_x1, b2_x1)
+    inter_y1 = max(b1_y1, b2_y1)
+    inter_x2 = min(b1_x2, b2_x2)
+    inter_y2 = min(b1_y2, b2_y2)
+    i_area = max(0, inter_x2 - inter_x1) * max(0, inter_y2 - inter_y1)
+
+    # 计算并集
+    b1_area = (b1_x2 - b1_x1) * (b1_y2 - b1_y1)
+    b2_area = (b2_x2 - b2_x1) * (b2_y2 - b2_y1)
+    u_area = b1_area + b2_area - i_area
+
+    # 避免除零错误，如果区域小到乘积为0,认为是错误识别，直接去掉
+    if u_area == 0:
+        return 1
+        # 检查完全包含
+    iou = i_area / u_area
+    return iou
+
+
+def caculate_single_axis_iou(box1: list | np.ndarray, box2: list | np.ndarray, axis='x') -> float:
+    """
+   :param box1: Iterable [xmin,ymin,xmax,ymax]
+   :param box2: Iterable [xmin,ymin,xmax,ymax]
+   :return: iou: float 0-1
+   """
+    b1_x1, b1_y1, b1_x2, b1_y2 = box1
+    b2_x1, b2_y1, b2_x2, b2_y2 = box2
+    if axis == 'x':
+        i_min = max(b1_x1, b2_x1)
+        i_max = min(b1_x2, b2_x2)
+        u_area = max(b1_x2, b2_x2) - min(b1_x1, b2_x1)
+    else:
+        i_min = max(b1_y1, b2_y1)
+        i_max = min(b1_y2, b2_y2)
+        u_area = max(b1_y2, b2_y2) - min(b1_y1, b2_y1)
+    i_area = max(i_max - i_min, 0)
+    if u_area == 0:
+        return 1
+    return i_area / u_area
+
+
+def is_box_contained(box1: list | np.ndarray, box2: list | np.ndarray, threshold=0.2) -> int | None:
+    """
+   :param box1: Iterable [xmin,ymin,xmax,ymax]
+   :param box2: Iterable [xmin,ymin,xmax,ymax]
+   :return: 1: box1 is contained 2: box2 is contained None: no contain these
+   """
+    b1_x1, b1_y1, b1_x2, b1_y2 = box1[0], box1[1], box1[2], box1[3]
+    b2_x1, b2_y1, b2_x2, b2_y2 = box2[0], box2[1], box2[2], box2[3]
+    # 不相交直接退出检测
+    if b1_x2 < b2_x1 or b1_x1 > b2_x2 or b1_y2 < b2_y1 or b1_y1 > b2_y2:
+        return None
+    # 计算box2的总面积
+    b2_area = (b2_x2 - b2_x1) * (b2_y2 - b2_y1)
+    b1_area = (b1_x2 - b1_x1) * (b1_y2 - b1_y1)
+
+    # 计算box1和box2的交集
+    intersect_x1 = max(b1_x1, b2_x1)
+    intersect_y1 = max(b1_y1, b2_y1)
+    intersect_x2 = min(b1_x2, b2_x2)
+    intersect_y2 = min(b1_y2, b2_y2)
+
+    # 计算交集的面积
+    intersect_area = max(0, intersect_x2 - intersect_x1) * max(0, intersect_y2 - intersect_y1)
+
+    # 计算外面的面积
+    b1_outside_area = b1_area - intersect_area
+    b2_outside_area = b2_area - intersect_area
+
+    # 计算外面的面积占box2总面积的比例
+    ratio_b1 = b1_outside_area / b1_area if b1_area > 0 else 0
+    ratio_b2 = b2_outside_area / b2_area if b2_area > 0 else 0
+
+    if ratio_b1 < threshold:
+        return 1
+    if ratio_b2 < threshold:
+        return 2
+    # 判断比例是否大于阈值
+    return None
+
+
+def is_single_axis_contained(box1: list | np.ndarray, box2: list | np.ndarray, axis='x', threshold=0.2) -> int | None:
+    """
+   :param box1: Iterable [xmin,ymin,xmax,ymax]
+   :param box2: Iterable [xmin,ymin,xmax,ymax]
+   :return: 1: box1 is contained 2: box2 is contained None: no contain these
+   """
+    b1_x1, b1_y1, b1_x2, b1_y2 = box1[0], box1[1], box1[2], box1[3]
+    b2_x1, b2_y1, b2_x2, b2_y2 = box2[0], box2[1], box2[2], box2[3]
+
+    # 计算轴重叠大小
+    if axis == 'x':
+        b1_area = (b1_x2 - b1_x1)
+        b2_area = (b2_x2 - b2_x1)
+        i_area = min(b1_x2, b2_x2) - max(b1_x1, b2_x1)
+    else:
+        b1_area = (b1_y2 - b1_y1)
+        b2_area = (b2_y2 - b2_y1)
+        i_area = min(b1_y2, b2_y2) - max(b1_y1, b2_y1)
+        # 计算外面的面积
+    b1_outside_area = b1_area - i_area
+    b2_outside_area = b2_area - i_area
+
+    ratio_b1 = b1_outside_area / b1_area if b1_area > 0 else 0
+    ratio_b2 = b2_outside_area / b2_area if b2_area > 0 else 0
+    if ratio_b1 < threshold:
+        return 1
+    if ratio_b2 < threshold:
+        return 2
+    return None
+
+
+def sorted_ocr_boxes(dt_boxes: np.ndarray | list) -> tuple[np.ndarray | list, list[int]]:
+    """
+    Sort text boxes in order from top to bottom, left to right
+    args:
+        dt_boxes(array):detected text boxes with (xmin, ymin, xmax, ymax)
+    return:
+        sorted boxes(array) with (xmin, ymin, xmax, ymax)
+    """
+    num_boxes = len(dt_boxes)
+    indexed_boxes = [(box, idx) for idx, box in enumerate(dt_boxes)]
+    sorted_boxes_with_idx = sorted(indexed_boxes, key=lambda x: (x[0][1], x[0][0]))
+    _boxes, indices = zip(*sorted_boxes_with_idx)
+    indices = list(indices)
+    _boxes = [dt_boxes[i] for i in indices]
+    for i in range(num_boxes - 1):
+        for j in range(i, -1, -1):
+            c_idx = is_single_axis_contained(_boxes[j], _boxes[j + 1], axis='y')
+            if c_idx is not None and _boxes[j + 1][0] < _boxes[j][0]:
+                _boxes[j], _boxes[j + 1] = _boxes[j + 1], _boxes[j]
+                indices[j], indices[j + 1] = indices[j + 1], indices[j]
+            else:
+                break
+    return _boxes, indices
+
+
+def gather_ocr_list_by_row(ocr_list: list[list[list[float], str]]) -> list[list[list[float], str]]:
+    """
+    :param ocr_list: [[[xmin,ymin,xmax,ymax], text]]
+    :return:
+    """
+    for i in range(len(ocr_list)):
+        if not ocr_list[i]:
+            continue
+        for j in range(i + 1, len(ocr_list)):
+            if not ocr_list[j]:
+                continue
+            cur = ocr_list[i]
+            next = ocr_list[j]
+            cur_box = cur[0]
+            next_box = next[0]
+            c_idx = is_single_axis_contained(cur[0], next[0], axis='y')
+            if c_idx:
+                cur[1] = cur[1] + next[1]
+                xmin = min(cur_box[0], next_box[0])
+                xmax = max(cur_box[2], next_box[2])
+                ymin = min(cur_box[1], next_box[1])
+                ymax = max(cur_box[3], next_box[3])
+                cur_box[0] = xmin
+                cur_box[1] = ymin
+                cur_box[2] = xmax
+                cur_box[3] = ymax
+                ocr_list[j] = None
+    ocr_list = [x for x in ocr_list if x]
+    return ocr_list
+
+def box_4_1_poly_to_box_4_2(poly_box: list | np.ndarray) -> list[list[float]]:
+    xmin, ymin, xmax, ymax = tuple(poly_box)
+    return [[xmin, ymin], [xmax, ymin], [xmax, ymax], [xmin, ymax]]
+
+
+def box_4_2_poly_to_box_4_1(poly_box: list | np.ndarray) -> list[ndarray[Any, Any]]:
+    """
+    将poly_box转换为box_4_1
+    :param poly_box:
+    :return:
+    """
+    return [poly_box[0][0], poly_box[0][1], poly_box[2][0], poly_box[2][1]]
 
 
 def merge_adjacent_polys(polygons: np.ndarray) -> np.ndarray:
@@ -122,91 +345,84 @@ def combine_two_poly(polygons: np.ndarray, idxs: np.ndarray) -> np.ndarray:
     return polygons
 
 
-def match_ocr_cell(
-    polygons: np.ndarray, ocr_res: List[Tuple[np.ndarray, str, str]]
-) -> Dict[int, List]:
-    cell_box_map = {}
-    dt_boxes, rec_res, _ = list(zip(*ocr_res))
-    dt_boxes = np.array(dt_boxes)
-    iou_thresh = 0.009
-    for i, cell_box in enumerate(polygons):
-        ious = [compute_poly_iou(dt_box, cell_box) for dt_box in dt_boxes]
-
-        # 对有iou的值，计算是否存在包含关系。如存在→iou=1
-        have_iou_idxs = np.argwhere(ious)
-        if have_iou_idxs.size > 0:
-            have_iou_idxs = have_iou_idxs.squeeze(1)
-            for idx in have_iou_idxs:
-                if is_inclusive_each_other(cell_box, dt_boxes[idx]):
-                    ious[idx] = 1.0
-
-        if all(x <= iou_thresh for x in ious):
-            # 说明这个cell中没有文本
-            cell_box_map.setdefault(i, []).append("")
-            continue
-
-        same_cell_idxs = np.argwhere(np.array(ious) >= iou_thresh).squeeze(1)
-        one_cell_txts = "\n".join([rec_res[idx] for idx in same_cell_idxs])
-        cell_box_map.setdefault(i, []).append(one_cell_txts)
-    return cell_box_map
-
-
-def is_inclusive_each_other(box1: np.ndarray, box2: np.ndarray):
-    """判断两个多边形框是否存在包含关系
-
-    Args:
-        box1 (np.ndarray): (4, 2)
-        box2 (np.ndarray): (4, 2)
-
-    Returns:
-        bool: 是否存在包含关系
+def match_ocr_cell(dt_rec_boxes: List[List[Union[Any, str]]], pred_bboxes: np.ndarray):
     """
-    poly1 = Polygon(box1)
-    poly2 = Polygon(box2)
+    :param dt_rec_boxes: [[(4.2), text, score]]
+    :param pred_bboxes: shap (4,2)
+    :return:
+    """
+    matched = {}
+    not_match_orc_boxes = []
+    for i, gt_box in enumerate(dt_rec_boxes):
+        for j, pred_box in enumerate(pred_bboxes):
+            pred_box = [pred_box[0][0], pred_box[0][1], pred_box[2][0], pred_box[2][1]]
+            ocr_boxes = gt_box[0]
+            # xmin,ymin,xmax,ymax
+            ocr_box = (ocr_boxes[0][0], ocr_boxes[0][1], ocr_boxes[2][0], ocr_boxes[2][1])
+            contained = is_box_contained(ocr_box, pred_box, 0.6)
+            if contained == 1 or calculate_iou(ocr_box, pred_box) > 0.8:
+                if j not in matched.keys():
+                    matched[j] = [gt_box]
+                else:
+                    matched[j].append(gt_box)
+            else:
+                not_match_orc_boxes.append(gt_box)
 
-    poly1_area = poly1.convex_hull.area
-    poly2_area = poly2.convex_hull.area
-
-    if poly1_area > poly2_area:
-        box_max = box1
-        box_min = box2
-    else:
-        box_max = box2
-        box_min = box1
-
-    x0, y0 = np.min(box_min[:, 0]), np.min(box_min[:, 1])
-    x1, y1 = np.max(box_min[:, 0]), np.max(box_min[:, 1])
-
-    edge_x0, edge_y0 = np.min(box_max[:, 0]), np.min(box_max[:, 1])
-    edge_x1, edge_y1 = np.max(box_max[:, 0]), np.max(box_max[:, 1])
-
-    if x0 >= edge_x0 and y0 >= edge_y0 and x1 <= edge_x1 and y1 <= edge_y1:
-        return True
-    return False
+    return matched, not_match_orc_boxes
 
 
-def plot_html_table(logi_points: np.ndarray, cell_box_map: Dict[int, List[str]]) -> str:
-    logi_points = logi_points.astype(np.int32)
-    table_dict = {}
-    for cell_idx, v in enumerate(logi_points):
-        cur_row = v[0]
-        cur_txt = "\n".join(cell_box_map.get(cell_idx))
-        sr, er, sc, ec = v.tolist()
-        rowspan, colspan = er - sr + 1, ec - sc + 1
-        table_str = f'<td rowspan="{rowspan}" colspan="{colspan}">{cur_txt}</td>'
-        # table_str = f'<td rowspan="{rowspan}" colspan="{colspan}"><div style="line-height: 18px;">{cur_txt}</div></td>'
-        table_dict.setdefault(cur_row, []).append(table_str)
+def plot_html_table(logi_points: np.ndarray | list, cell_box_map: Dict[int, List[str]]) -> str:
+    # 初始化最大行数和列数
+    max_row = 0
+    max_col = 0
+    # 计算最大行数和列数
+    for point  in logi_points:
+        max_row = max(max_row, point[1] + 1)  # 加1是因为结束下标是包含在内的
+        max_col = max(max_col, point[3] + 1)  # 加1是因为结束下标是包含在内的
 
-    new_table_dict = {}
-    for k, v in table_dict.items():
-        new_table_dict[k] = ["<tr>"] + v + ["</tr>"]
+    # 创建一个二维数组来存储 sorted_logi_points 中的元素
+    grid = [[None] * max_col for _ in range(max_row)]
 
-    html_start = """<html><body><table><tbody>"""
-    # html_start = """<html><style type="text/css">td {border-left: 1px solid;border-bottom:1px solid;}table, th {border-top:1px solid;font-size: 10px;border-collapse: collapse;border-right: 1px solid;}</style><body><table style="border-bottom:1px solid;border-top:1px solid;"><tbody>"""
-    html_end = "</tbody></table></body></html>"
-    html_middle = "".join([vv for v in new_table_dict.values() for vv in v])
-    table_str = f"{html_start}{html_middle}{html_end}"
-    return table_str
+    # 将 sorted_logi_points 中的元素填充到 grid 中
+    for i, logic_point in enumerate(logi_points):
+        row_start, row_end, col_start, col_end = logic_point[0],logic_point[1],logic_point[2],logic_point[3]
+        for row in range(row_start, row_end + 1):
+            for col in range(col_start, col_end + 1):
+                grid[row][col] = (i, row_start, row_end, col_start, col_end)
+
+    # 创建表格
+    table_html = "<table>\n"
+
+    # 遍历每行
+    for row in range(max_row):
+        empty_temp = True
+        temp = "  <tr>\n"
+
+        # 遍历每一列
+        for col in range(max_col):
+            if not grid[row][col]:
+                temp += "    <td></td>\n"
+            else:
+                i, row_start, row_end, col_start, col_end = grid[row][col]
+                if not cell_box_map.get(i):
+                    continue
+                empty_temp = False
+                if (row == row_start and col == col_start):
+                    ocr_rec_text = cell_box_map.get(i)
+                    text = "<br>".join(ocr_rec_text)
+                    if not text.strip():
+                        continue
+                    # 如果是起始单元格
+                    row_span = row_end - row_start + 1
+                    col_span = col_end - col_start + 1
+                    cell_content = f"<td rowspan={row_span} colspan={col_span}>{text}</td>\n"
+                    temp += cell_content
+        if not empty_temp:
+            table_html = table_html + temp + "  </tr>\n"
+
+    table_html += "</table>"
+    return table_html
+
 
 
 def vis_table(img: np.ndarray, polygons: np.ndarray) -> np.ndarray:
@@ -223,7 +439,105 @@ def vis_table(img: np.ndarray, polygons: np.ndarray) -> np.ndarray:
         cv2.putText(img, str(i), poly[0], font, 1, (0, 0, 255), 2)
     return img
 
+def plot_rec_box_with_logic_info(img_path, output_path, logic_points, sorted_polygons):
+    """
+    :param img_path
+    :param output_path
+    :param logic_points: [row_start,row_end,col_start,col_end]
+    :param sorted_polygons: [xmin,ymin,xmax,ymax]
+    :return:
+    """
+    # 读取原图
+    img = cv2.imread(img_path)
+    img = cv2.copyMakeBorder(img, 0, 0, 0, 100, cv2.BORDER_CONSTANT, value=[255, 255, 255])
+    # 绘制 polygons 矩形
+    for idx, polygon in enumerate(sorted_polygons):
+        x0, y0, x1, y1 = polygon[0], polygon[1], polygon[2], polygon[3]
+        x0 = round(x0)
+        y0 = round(y0)
+        x1 = round(x1)
+        y1 = round(y1)
+        cv2.rectangle(img, (x0, y0), (x1, y1), (0, 0, 255), 1)
+        # 增大字体大小和线宽
+        font_scale = 1.0  # 原先是0.5
+        thickness = 2  # 原先是1
 
+        cv2.putText(
+            img,
+            f'{idx}-{logic_points[idx]}',
+            (x1, y1),
+            cv2.FONT_HERSHEY_PLAIN,
+            font_scale,
+            (0, 0, 255),
+            thickness,
+        )
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        # 保存绘制后的图像
+        cv2.imwrite(output_path, img)
+
+def plot_rec_box(img_path, output_path, sorted_polygons):
+    """
+    :param img_path
+    :param output_path
+    :param sorted_polygons: [xmin,ymin,xmax,ymax]
+    :return:
+    """
+    # 处理ocr_res
+    img = cv2.imread(img_path)
+    img = cv2.copyMakeBorder(img, 0, 0, 0, 100, cv2.BORDER_CONSTANT, value=[255, 255, 255])
+    # 绘制 ocr_res 矩形
+    for idx, polygon in enumerate(sorted_polygons):
+        x0, y0, x1, y1 = polygon[0], polygon[1], polygon[2], polygon[3]
+        x0 = round(x0)
+        y0 = round(y0)
+        x1 = round(x1)
+        y1 = round(y1)
+        cv2.rectangle(img, (x0, y0), (x1, y1), (0, 0, 255), 1)
+        # 增大字体大小和线宽
+        font_scale = 1.0  # 原先是0.5
+        thickness = 2  # 原先是1
+
+        cv2.putText(
+            img,
+            str(idx),
+            (x1, y1),
+            cv2.FONT_HERSHEY_PLAIN,
+            font_scale,
+            (0, 0, 255),
+            thickness,
+        )
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    # 保存绘制后的图像
+    cv2.imwrite(output_path, img)
+
+def format_html(html):
+
+    return f"""
+    <!DOCTYPE html>
+    <html lang="zh-CN">
+    <head>
+    <meta charset="UTF-8">
+    <title>Complex Table Example</title>
+    <style>
+        table {{
+            border-collapse: collapse;
+            width: 100%;
+        }}
+        th, td {{
+            border: 1px solid black;
+            padding: 8px;
+            text-align: center;
+        }}
+        th {{
+            background-color: #f2f2f2;
+        }}
+    </style>
+    </head>
+    <body>
+    {html}
+    </body>
+    </html>
+    """
 def get_rotate_crop_image(img: np.ndarray, points: np.ndarray) -> np.ndarray:
     img_crop_width = int(
         max(


### PR DESCRIPTION
1. 根据ocr识别框修正了表格的识别框边界
2. 优化ocr排序逻辑，从固定y 10 的偏差容忍改为y方向偏移量/y方向总长度 < threshold
3. 优化了判断包含关系的逻辑，改为非交集面积 / 两个box各自总面积 < threshold 决定包含和被包含
4. 将逻辑坐标相同的识别框对应的ocr结果合并
5. 修正了html构建时的逻辑，以模型输出的逻辑坐标为准
6. 构建了表格grid,后续todo完善ocr识别框补充表格漏识别
7. 将main方法中引入包由相对路径改为绝对路径（应该不影响使用吧，相对路径我本地无法执行）

执行main.py,会在output中生成两张带识别框和排序的图片，以及html，方便验证结果
![image](https://github.com/user-attachments/assets/9d3d83f7-e762-49e4-93c3-88c51911151d)
