### PR TITLE
adapt for py 3.8 & add text oritation for wired table

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,16 @@ print(f"elasp: {elasp}")
 # # 可视化 ocr 识别框
 # plot_rec_box(img_path, f"{output_dir}/ocr_box.jpg", ocr_res)
 ```
-
+#### 偏移修正
+```python
+import cv2
+img_path = f'tests/test_files/wired/squeeze_error.jpeg'
+from wired_table_rec.utils import ImageOrientationCorrector
+img_orientation_corrector = ImageOrientationCorrector()
+img = cv2.imread(img_path)
+img = img_orientation_corrector(img)
+cv2.imwrite(f'img_rotated.jpg', img)
+```
 ## FAQ (Frequently Asked Questions)
 
 1. **问：偏移的图片能够处理吗？**
@@ -101,7 +110,7 @@ print(f"elasp: {elasp}")
 
 ### TODO List
 
-- [ ] 识别前图片偏移修正
+- [ ] 识别前图片偏移修正(完成有线表格小角度偏移修正)
 - [ ] 增加数据集数量，增加更多评测对比
 - [ ] 优化无线表格模型
 

--- a/lineless_table_rec/main.py
+++ b/lineless_table_rec/main.py
@@ -119,10 +119,10 @@ class LinelessTableRecognition:
 
     def transform_res(
         self,
-        cell_box_det_map: dict[int, List[any]],
+        cell_box_det_map: Dict[int, List[any]],
         polygons: np.ndarray,
         logi_points: List[np.ndarray],
-    ) -> List[dict[str, any]]:
+    ) -> List[Dict[str, any]]:
         res = []
         for i in range(len(polygons)):
             ocr_res_list = cell_box_det_map.get(i)

--- a/lineless_table_rec/utils_table_recover.py
+++ b/lineless_table_rec/utils_table_recover.py
@@ -96,7 +96,7 @@ def filter_duplicated_box(table_boxes: List[List[float]]) -> Set[int]:
 
 
 def calculate_iou(
-    box1: Union[np.ndarray, list], box2: Union[np.ndarray, list]
+    box1: Union[np.ndarray, List], box2: Union[np.ndarray, List]
 ) -> float:
     """
     :param box1: Iterable [xmin,ymin,xmax,ymax]
@@ -129,7 +129,7 @@ def calculate_iou(
 
 
 def caculate_single_axis_iou(
-    box1: Union[np.ndarray, list], box2: Union[np.ndarray, list], axis="x"
+    box1: Union[np.ndarray, List], box2: Union[np.ndarray, List], axis="x"
 ) -> float:
     """
     :param box1: Iterable [xmin,ymin,xmax,ymax]
@@ -153,7 +153,7 @@ def caculate_single_axis_iou(
 
 
 def is_box_contained(
-    box1: Union[np.ndarray, list], box2: Union[np.ndarray, list], threshold=0.2
+    box1: Union[np.ndarray, List], box2: Union[np.ndarray, List], threshold=0.2
 ) -> Union[int, None]:
     """
     :param box1: Iterable [xmin,ymin,xmax,ymax]

--- a/lineless_table_rec/utils_table_recover.py
+++ b/lineless_table_rec/utils_table_recover.py
@@ -3,7 +3,7 @@
 # @Contact: liekkaskono@163.com
 import os
 import random
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Union, Set, Tuple
 
 import cv2
 import numpy as np
@@ -67,7 +67,7 @@ def compute_poly_iou(a: np.ndarray, b: np.ndarray) -> float:
     return float(inter_area) / union_area
 
 
-def filter_duplicated_box(table_boxes: list[list[float]]) -> set[int]:
+def filter_duplicated_box(table_boxes: List[List[float]]) -> Set[int]:
     """
     :param table_boxes: [[xmin,ymin,xmax,ymax]]
     :return:
@@ -95,7 +95,9 @@ def filter_duplicated_box(table_boxes: list[list[float]]) -> set[int]:
     return delete_idx
 
 
-def calculate_iou(box1: list | np.ndarray, box2: list | np.ndarray) -> float:
+def calculate_iou(
+    box1: Union[np.ndarray, list], box2: Union[np.ndarray, list]
+) -> float:
     """
     :param box1: Iterable [xmin,ymin,xmax,ymax]
     :param box2: Iterable [xmin,ymin,xmax,ymax]
@@ -127,7 +129,7 @@ def calculate_iou(box1: list | np.ndarray, box2: list | np.ndarray) -> float:
 
 
 def caculate_single_axis_iou(
-    box1: list | np.ndarray, box2: list | np.ndarray, axis="x"
+    box1: Union[np.ndarray, list], box2: Union[np.ndarray, list], axis="x"
 ) -> float:
     """
     :param box1: Iterable [xmin,ymin,xmax,ymax]
@@ -151,8 +153,8 @@ def caculate_single_axis_iou(
 
 
 def is_box_contained(
-    box1: list | np.ndarray, box2: list | np.ndarray, threshold=0.2
-) -> int | None:
+    box1: Union[np.ndarray, list], box2: Union[np.ndarray, list], threshold=0.2
+) -> Union[int, None]:
     """
     :param box1: Iterable [xmin,ymin,xmax,ymax]
     :param box2: Iterable [xmin,ymin,xmax,ymax]
@@ -195,8 +197,8 @@ def is_box_contained(
 
 
 def is_single_axis_contained(
-    box1: list | np.ndarray, box2: list | np.ndarray, axis="x", threhold=0.2
-) -> int | None:
+    box1: Union[np.ndarray, list], box2: Union[np.ndarray, list], axis="x", threhold=0.2
+) -> Union[int, None]:
     """
     :param box1: Iterable [xmin,ymin,xmax,ymax]
     :param box2: Iterable [xmin,ymin,xmax,ymax]
@@ -228,8 +230,8 @@ def is_single_axis_contained(
 
 
 def sorted_ocr_boxes(
-    dt_boxes: np.ndarray | list, threhold: float = 0.2
-) -> tuple[np.ndarray | list, list[int]]:
+    dt_boxes: Union[np.ndarray, List], threhold: float = 0.2
+) -> Tuple[Union[np.ndarray, list], List[int]]:
     """
     Sort text boxes in order from top to bottom, left to right
     args:
@@ -266,9 +268,7 @@ def sorted_ocr_boxes(
     return _boxes, indices
 
 
-def gather_ocr_list_by_row(
-    ocr_list: list[list[list[float], str]], thehold: float = 0.2
-) -> list[list[list[float], str]]:
+def gather_ocr_list_by_row(ocr_list: List[Any], thehold: float = 0.2) -> List[Any]:
     """
     :param ocr_list: [[[xmin,ymin,xmax,ymax], text]]
     :return:
@@ -305,12 +305,12 @@ def gather_ocr_list_by_row(
     return ocr_list
 
 
-def box_4_1_poly_to_box_4_2(poly_box: list | np.ndarray) -> list[list[float]]:
+def box_4_1_poly_to_box_4_2(poly_box: Union[np.ndarray, list]) -> List[List[float]]:
     xmin, ymin, xmax, ymax = tuple(poly_box)
     return [[xmin, ymin], [xmax, ymin], [xmax, ymax], [xmin, ymax]]
 
 
-def box_4_2_poly_to_box_4_1(poly_box: list | np.ndarray) -> list[float]:
+def box_4_2_poly_to_box_4_1(poly_box: Union[np.ndarray, list]) -> List[float]:
     """
     将poly_box转换为box_4_1
     :param poly_box:
@@ -407,7 +407,7 @@ def match_ocr_cell(dt_rec_boxes: List[List[Union[Any, str]]], pred_bboxes: np.nd
 
 
 def plot_html_table(
-    logi_points: np.ndarray | list, cell_box_map: Dict[int, List[str]]
+    logi_points: Union[np.ndarray, list], cell_box_map: Dict[int, List[str]]
 ) -> str:
     # 初始化最大行数和列数
     max_row = 0

--- a/setup_table_cls.py
+++ b/setup_table_cls.py
@@ -1,12 +1,13 @@
 # -*- encoding: utf-8 -*-
 # @Author: SWHL
 # @Contact: liekkaskono@163.com
+import sys
 from pathlib import Path
 from typing import List, Union
 
 import setuptools
 
-# from get_pypi_latest_version import GetPyPiLatestVersion
+from get_pypi_latest_version import GetPyPiLatestVersion
 
 
 def read_txt(txt_path: Union[Path, str]) -> List[str]:
@@ -17,21 +18,20 @@ def read_txt(txt_path: Union[Path, str]) -> List[str]:
 
 MODULE_NAME = "table_cls"
 
-# obtainer = GetPyPiLatestVersion()
-# try:
-#     latest_version = obtainer(MODULE_NAME)
-# except Exception:
-#     latest_version = "0.0.0"
-#
-# VERSION_NUM = obtainer.version_add_one(latest_version)
-VERSION_NUM = "1.0.0"
+obtainer = GetPyPiLatestVersion()
+try:
+    latest_version = obtainer(MODULE_NAME)
+except Exception:
+    latest_version = "0.0.0"
 
-# if len(sys.argv) > 2:
-#     match_str = " ".join(sys.argv[2:])
-#     matched_versions = obtainer.extract_version(match_str)
-#     if matched_versions:
-#         VERSION_NUM = matched_versions
-# sys.argv = sys.argv[:2]
+VERSION_NUM = obtainer.version_add_one(latest_version)
+
+if len(sys.argv) > 2:
+    match_str = " ".join(sys.argv[2:])
+    matched_versions = obtainer.extract_version(match_str)
+    if matched_versions:
+        VERSION_NUM = matched_versions
+sys.argv = sys.argv[:2]
 
 setuptools.setup(
     name=MODULE_NAME,

--- a/tests/test_wired_table_rec.py
+++ b/tests/test_wired_table_rec.py
@@ -41,7 +41,7 @@ def test_squeeze_bug():
     ocr_result, _ = ocr_engine(img_path)
     table_str, *_ = table_recog(str(img_path), ocr_result)
     td_nums = get_td_nums(table_str)
-    assert td_nums == 228
+    assert td_nums == 291
 
 
 @pytest.mark.parametrize(

--- a/wired_table_rec/main.py
+++ b/wired_table_rec/main.py
@@ -7,7 +7,7 @@ import logging
 import time
 import traceback
 from pathlib import Path
-from typing import List, Optional, Tuple, Union, Dict
+from typing import List, Optional, Tuple, Union, Dict, Any
 import numpy as np
 import cv2
 
@@ -50,7 +50,7 @@ class WiredTableRecognition:
         self,
         img: InputType,
         ocr_result: Optional[List[Union[List[List[float]], str, str]]] = None,
-    ) -> Tuple[str, float, list]:
+    ) -> Tuple[str, float, Any, Any, Any]:
         if self.ocr is None and ocr_result is None:
             raise ValueError(
                 "One of two conditions must be met: ocr_result is not empty, or rapidocr_onnxruntime is installed."
@@ -109,10 +109,10 @@ class WiredTableRecognition:
 
     def transform_res(
         self,
-        cell_box_det_map: dict[int, List[any]],
+        cell_box_det_map: Dict[int, List[any]],
         polygons: np.ndarray,
         logi_points: List[np.ndarray],
-    ) -> List[dict[str, any]]:
+    ) -> List[Dict[str, any]]:
         res = []
         for i in range(len(polygons)):
             ocr_res_list = cell_box_det_map.get(i)
@@ -152,7 +152,7 @@ class WiredTableRecognition:
         img: np.ndarray,
         sorted_polygons: np.ndarray,
         cell_box_map: Dict[int, List[str]],
-    ) -> Dict[int, List[any]]:
+    ) -> Dict[int, List[Any]]:
         """找到poly对应为空的框，尝试将直接将poly框直接送到识别中"""
         #
         for i in range(sorted_polygons.shape[0]):

--- a/wired_table_rec/table_line_rec.py
+++ b/wired_table_rec/table_line_rec.py
@@ -48,7 +48,9 @@ class TableLineRecognition:
             [box_4_2_poly_to_box_4_1(box) for box in polygons]
         )
         polygons = np.delete(polygons, list(del_idxs), axis=0)
-        _, idx = sorted_ocr_boxes([box_4_2_poly_to_box_4_1(box) for box in polygons])
+        _, idx = sorted_ocr_boxes(
+            [box_4_2_poly_to_box_4_1(box) for box in polygons], threhold=0.4
+        )
         polygons = polygons[idx]
         polygons = merge_adjacent_polys(polygons)
         return polygons

--- a/wired_table_rec/table_line_rec_plus.py
+++ b/wired_table_rec/table_line_rec_plus.py
@@ -44,7 +44,7 @@ class TableLineRecognitionPlus:
             polygons[:, 3, :].copy(),
         )
         _, idx = sorted_ocr_boxes(
-            [box_4_2_poly_to_box_4_1(poly_box) for poly_box in polygons]
+            [box_4_2_poly_to_box_4_1(poly_box) for poly_box in polygons], threhold=0.4
         )
         polygons = polygons[idx]
         return polygons

--- a/wired_table_rec/table_recover.py
+++ b/wired_table_rec/table_recover.py
@@ -114,38 +114,6 @@ class TableRecover:
     ) -> Tuple[np.ndarray, List[float], int]:
         leftmost_cell_idxs = [v[0] for v in rows.values()]
         benchmark_x = polygons[leftmost_cell_idxs][:, 0, 1]
-        #  有线表格模型精度足够，不进行工程化修正，避免更多未知问题
-        # theta = 15
-        # 遍历其他所有的框，按照y轴进行区间划分
-        # range_res = {}
-        # for cur_idx, cur_box in enumerate(polygons):
-        #     # fix cur_idx in benchmark_x
-        #     if cur_idx in leftmost_cell_idxs:
-        #         continue
-        #
-        #     cur_y = cur_box[0, 1]
-        #
-        #     start_idx, end_idx = None, None
-        #     for i, v in enumerate(benchmark_x):
-        #         if cur_y - theta <= v <= cur_y + theta:
-        #             break
-        #
-        #         if cur_y > v:
-        #             start_idx = i
-        #             continue
-        #
-        #         if cur_y < v:
-        #             end_idx = i
-        #             break
-        #
-        #     range_res[cur_idx] = [start_idx, end_idx]
-        #
-        # sorted_res = dict(sorted(range_res.items(), key=lambda x: x[0], reverse=True))
-        # for k, v in sorted_res.items():
-        #     if not all(v):
-        #         continue
-        #
-        #     benchmark_x = np.insert(benchmark_x, v[1], polygons[k][0, 1])
 
         each_row_widths = (benchmark_x[1:] - benchmark_x[:-1]).tolist()
 

--- a/wired_table_rec/table_recover.py
+++ b/wired_table_rec/table_recover.py
@@ -114,38 +114,38 @@ class TableRecover:
     ) -> Tuple[np.ndarray, List[float], int]:
         leftmost_cell_idxs = [v[0] for v in rows.values()]
         benchmark_x = polygons[leftmost_cell_idxs][:, 0, 1]
-
-        theta = 15
+        #  有线表格模型精度足够，不进行工程化修正，避免更多未知问题
+        # theta = 15
         # 遍历其他所有的框，按照y轴进行区间划分
-        range_res = {}
-        for cur_idx, cur_box in enumerate(polygons):
-            # fix cur_idx in benchmark_x
-            if cur_idx in leftmost_cell_idxs:
-                continue
-
-            cur_y = cur_box[0, 1]
-
-            start_idx, end_idx = None, None
-            for i, v in enumerate(benchmark_x):
-                if cur_y - theta <= v <= cur_y + theta:
-                    break
-
-                if cur_y > v:
-                    start_idx = i
-                    continue
-
-                if cur_y < v:
-                    end_idx = i
-                    break
-
-            range_res[cur_idx] = [start_idx, end_idx]
-
-        sorted_res = dict(sorted(range_res.items(), key=lambda x: x[0], reverse=True))
-        for k, v in sorted_res.items():
-            if not all(v):
-                continue
-
-            benchmark_x = np.insert(benchmark_x, v[1], polygons[k][0, 1])
+        # range_res = {}
+        # for cur_idx, cur_box in enumerate(polygons):
+        #     # fix cur_idx in benchmark_x
+        #     if cur_idx in leftmost_cell_idxs:
+        #         continue
+        #
+        #     cur_y = cur_box[0, 1]
+        #
+        #     start_idx, end_idx = None, None
+        #     for i, v in enumerate(benchmark_x):
+        #         if cur_y - theta <= v <= cur_y + theta:
+        #             break
+        #
+        #         if cur_y > v:
+        #             start_idx = i
+        #             continue
+        #
+        #         if cur_y < v:
+        #             end_idx = i
+        #             break
+        #
+        #     range_res[cur_idx] = [start_idx, end_idx]
+        #
+        # sorted_res = dict(sorted(range_res.items(), key=lambda x: x[0], reverse=True))
+        # for k, v in sorted_res.items():
+        #     if not all(v):
+        #         continue
+        #
+        #     benchmark_x = np.insert(benchmark_x, v[1], polygons[k][0, 1])
 
         each_row_widths = (benchmark_x[1:] - benchmark_x[:-1]).tolist()
 

--- a/wired_table_rec/utils_table_recover.py
+++ b/wired_table_rec/utils_table_recover.py
@@ -37,7 +37,7 @@ def sorted_boxes(dt_boxes: np.ndarray) -> np.ndarray:
 
 
 def calculate_iou(
-    box1: Union[np.ndarray, list], box2: Union[np.ndarray, list]
+    box1: Union[np.ndarray, List], box2: Union[np.ndarray, List]
 ) -> float:
     """
     :param box1: Iterable [xmin,ymin,xmax,ymax]
@@ -70,7 +70,7 @@ def calculate_iou(
 
 
 def caculate_single_axis_iou(
-    box1: Union[np.ndarray, list], box2: Union[np.ndarray, list], axis="x"
+    box1: Union[np.ndarray, List], box2: Union[np.ndarray, List], axis="x"
 ) -> float:
     """
     :param box1: Iterable [xmin,ymin,xmax,ymax]
@@ -94,7 +94,7 @@ def caculate_single_axis_iou(
 
 
 def is_box_contained(
-    box1: Union[np.ndarray, list], box2: Union[np.ndarray, list], threshold=0.2
+    box1: Union[np.ndarray, List], box2: Union[np.ndarray, List], threshold=0.2
 ) -> Union[int, None]:
     """
     :param box1: Iterable [xmin,ymin,xmax,ymax]
@@ -138,8 +138,8 @@ def is_box_contained(
 
 
 def is_single_axis_contained(
-    box1: Union[np.ndarray, list],
-    box2: Union[np.ndarray, list],
+    box1: Union[np.ndarray, List],
+    box2: Union[np.ndarray, List],
     axis="x",
     threhold: float = 0.2,
 ) -> Union[int, None]:
@@ -558,7 +558,7 @@ def is_inclusive_each_other(box1: np.ndarray, box2: np.ndarray):
 
 
 def plot_html_table(
-    logi_points: Union[Union[np.ndarray, list]], cell_box_map: Dict[int, List[str]]
+    logi_points: Union[Union[np.ndarray, List]], cell_box_map: Dict[int, List[str]]
 ) -> str:
     # 初始化最大行数和列数
     max_row = 0

--- a/wired_table_rec/utils_table_recover.py
+++ b/wired_table_rec/utils_table_recover.py
@@ -3,7 +3,7 @@
 # @Contact: liekkaskono@163.com
 import os
 import random
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Union, Set, Tuple
 
 import cv2
 import numpy as np
@@ -36,7 +36,9 @@ def sorted_boxes(dt_boxes: np.ndarray) -> np.ndarray:
     return np.array(_boxes)
 
 
-def calculate_iou(box1: list | np.ndarray, box2: list | np.ndarray) -> float:
+def calculate_iou(
+    box1: Union[np.ndarray, list], box2: Union[np.ndarray, list]
+) -> float:
     """
     :param box1: Iterable [xmin,ymin,xmax,ymax]
     :param box2: Iterable [xmin,ymin,xmax,ymax]
@@ -68,7 +70,7 @@ def calculate_iou(box1: list | np.ndarray, box2: list | np.ndarray) -> float:
 
 
 def caculate_single_axis_iou(
-    box1: list | np.ndarray, box2: list | np.ndarray, axis="x"
+    box1: Union[np.ndarray, list], box2: Union[np.ndarray, list], axis="x"
 ) -> float:
     """
     :param box1: Iterable [xmin,ymin,xmax,ymax]
@@ -92,8 +94,8 @@ def caculate_single_axis_iou(
 
 
 def is_box_contained(
-    box1: list | np.ndarray, box2: list | np.ndarray, threshold=0.2
-) -> int | None:
+    box1: Union[np.ndarray, list], box2: Union[np.ndarray, list], threshold=0.2
+) -> Union[int, None]:
     """
     :param box1: Iterable [xmin,ymin,xmax,ymax]
     :param box2: Iterable [xmin,ymin,xmax,ymax]
@@ -136,8 +138,11 @@ def is_box_contained(
 
 
 def is_single_axis_contained(
-    box1: list | np.ndarray, box2: list | np.ndarray, axis="x", threhold: float = 0.2
-) -> int | None:
+    box1: Union[np.ndarray, list],
+    box2: Union[np.ndarray, list],
+    axis="x",
+    threhold: float = 0.2,
+) -> Union[int, None]:
     """
     :param box1: Iterable [xmin,ymin,xmax,ymax]
     :param box2: Iterable [xmin,ymin,xmax,ymax]
@@ -168,7 +173,7 @@ def is_single_axis_contained(
     return None
 
 
-def filter_duplicated_box(table_boxes: list[list[float]]) -> set[int]:
+def filter_duplicated_box(table_boxes: List[List[float]]) -> Set[int]:
     """
     :param table_boxes: [[xmin,ymin,xmax,ymax]]
     :return:
@@ -197,8 +202,8 @@ def filter_duplicated_box(table_boxes: list[list[float]]) -> set[int]:
 
 
 def sorted_ocr_boxes(
-    dt_boxes: np.ndarray | list, threhold: float = 0.2
-) -> tuple[np.ndarray | list, list[int]]:
+    dt_boxes: Union[np.ndarray, list], threhold: float = 0.2
+) -> Tuple[Union[np.ndarray, list], List[int]]:
     """
     Sort text boxes in order from top to bottom, left to right
     args:
@@ -312,12 +317,12 @@ def plot_rec_box(img_path, output_path, sorted_polygons):
     cv2.imwrite(output_path, img)
 
 
-def box_4_1_poly_to_box_4_2(poly_box: list | np.ndarray) -> list[list[float]]:
+def box_4_1_poly_to_box_4_2(poly_box: Union[list, np.ndarray]) -> List[List[float]]:
     xmin, ymin, xmax, ymax = tuple(poly_box)
     return [[xmin, ymin], [xmax, ymin], [xmax, ymax], [xmin, ymax]]
 
 
-def box_4_2_poly_to_box_4_1(poly_box: list | np.ndarray) -> list[float]:
+def box_4_2_poly_to_box_4_1(poly_box: Union[list, np.ndarray]) -> List[Any]:
     """
     将poly_box转换为box_4_1
     :param poly_box:
@@ -357,9 +362,7 @@ def match_ocr_cell(dt_rec_boxes: List[List[Union[Any, str]]], pred_bboxes: np.nd
     return matched, not_match_orc_boxes
 
 
-def gather_ocr_list_by_row(
-    ocr_list: list[list[list[float], str]], threhold: float = 0.2
-) -> list[list[list[float], str]]:
+def gather_ocr_list_by_row(ocr_list: List[Any], threhold: float = 0.2) -> List[Any]:
     """
     :param ocr_list: [[[xmin,ymin,xmax,ymax], text]]
     :return:
@@ -555,7 +558,7 @@ def is_inclusive_each_other(box1: np.ndarray, box2: np.ndarray):
 
 
 def plot_html_table(
-    logi_points: np.ndarray | list, cell_box_map: Dict[int, List[str]]
+    logi_points: Union[Union[np.ndarray, list]], cell_box_map: Dict[int, List[str]]
 ) -> str:
     # 初始化最大行数和列数
     max_row = 0


### PR DESCRIPTION
1. 去掉了有线表格的benchmark row,以模型输出的精度为依据，尽可能减少工程干预
2. 增加了基于霍夫直线和透视变换的小角度偏移识别和矫正方法，适用边缘清晰的有线表格
3. 调整了部分函数的出参和入参，适配3.8及以上版本的python