### PR TITLE
fix:  keyword errors & missing import

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ from lineless_table_rec import LinelessTableRecognition
 from lineless_table_rec.utils_table_recover import format_html, plot_rec_box_with_logic_info, plot_rec_box
 from table_cls import TableCls
 from wired_table_rec import WiredTableRecognition
+from rapidocr_onnxruntime import RapidOCR 
 
 lineless_engine = LinelessTableRecognition()
 wired_engine = WiredTableRecognition()
@@ -106,7 +107,7 @@ html, elasp, polygons, logic_points, ocr_res = table_engine(img_path)
 print(f"elasp: {elasp}")
 
 # 使用其他ocr模型
-#ocr_engine =RapidOCR(det_model_dir="xxx/det_server_infer.onnx",rec_model_dir="xxx/rec_server_infer.onnx")
+#ocr_engine =RapidOCR(det_model_path="xxx/det_server_infer.onnx",rec_model_path="xxx/rec_server_infer.onnx")
 #ocr_res, _ = ocr_engine(img_path)
 #html, elasp, polygons, logic_points, ocr_res = table_engine(img_path, ocr_result=ocr_res)
 # output_dir = f'outputs'

--- a/README_en.md
+++ b/README_en.md
@@ -87,6 +87,7 @@ from lineless_table_rec import LinelessTableRecognition
 from lineless_table_rec.utils_table_recover import format_html, plot_rec_box_with_logic_info, plot_rec_box
 from table_cls import TableCls
 from wired_table_rec import WiredTableRecognition
+from rapidocr_onnxruntime import RapidOCR 
 
 lineless_engine = LinelessTableRecognition()
 wired_engine = WiredTableRecognition()
@@ -104,7 +105,7 @@ html, elasp, polygons, logic_points, ocr_res = table_engine(img_path)
 print(f"elasp: {elasp}")
 
 # Use other OCR models
-#ocr_engine =RapidOCR(det_model_dir="xxx/det_server_infer.onnx",rec_model_dir="xxx/rec_server_infer.onnx")
+#ocr_engine =RapidOCR(det_model_path="xxx/det_server_infer.onnx",rec_model_path="xxx/rec_server_infer.onnx")
 #ocr_res, _ = ocr_engine(img_path)
 #html, elasp, polygons, logic_points, ocr_res = table_engine(img_path, ocr_result=ocr_res)  
 


### PR DESCRIPTION
##  引用缺失
在README文件中增加了RapidOCR的引用语句。使得用户在初次使用时不需要在寻找应该从哪里引用
## 关键词错误
不知道是不是因为版本升级，现在的`rapidocr_onnxruntime==1.4.4`模型路径为xx_path 而不是xx_dir
